### PR TITLE
Add missing math include

### DIFF
--- a/glm/detail/type_vec3.hpp
+++ b/glm/detail/type_vec3.hpp
@@ -12,6 +12,7 @@
 #	endif
 #endif //GLM_SWIZZLE == GLM_SWIZZLE_ENABLED
 #include <cstddef>
+#include <cmath>
 
 namespace glm
 {


### PR DESCRIPTION
Our OpenMesh glue code adds a `norm` function which needs access to the `sqrt` function which is not included in this file.